### PR TITLE
add chat message functionality with create and retrieve endpoints

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -21,10 +21,6 @@
           <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok-mapstruct-binding/0.2.0/lombok-mapstruct-binding-0.2.0.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct-processor/1.5.5.Final/mapstruct-processor-1.5.5.Final.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct/1.5.5.Final/mapstruct-1.5.5.Final.jar" />
-          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.30/lombok-1.18.30.jar" />
-          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok-mapstruct-binding/0.2.0/lombok-mapstruct-binding-0.2.0.jar" />
-          <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct-processor/1.5.5.Final/mapstruct-processor-1.5.5.Final.jar" />
-          <entry name="$MAVEN_REPOSITORY$/org/mapstruct/mapstruct/1.5.5.Final/mapstruct-1.5.5.Final.jar" />
         </processorPath>
         <module name="chat-service" />
         <module name="profile-service" />

--- a/chat-service/src/main/java/com/vti/chat/controller/ChatMessageController.java
+++ b/chat-service/src/main/java/com/vti/chat/controller/ChatMessageController.java
@@ -1,0 +1,37 @@
+package com.vti.chat.controller;
+
+import com.vti.chat.dto.ApiResponse;
+import com.vti.chat.dto.request.ChatMessageRequest;
+import com.vti.chat.dto.response.ChatMessageResponse;
+import com.vti.chat.service.ChatMessageService;
+import jakarta.validation.Valid;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("messages")
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class ChatMessageController {
+    ChatMessageService chatMessageService;
+
+    @PostMapping("/create")
+    ApiResponse<ChatMessageResponse> create(
+            @RequestBody @Valid ChatMessageRequest request) {
+        return ApiResponse.<ChatMessageResponse>builder()
+                .result(chatMessageService.create(request))
+                .build();
+    }
+
+    @GetMapping
+    ApiResponse<List<ChatMessageResponse>> getMessages(
+            @RequestParam("conversationId") String conversationId) {
+        return ApiResponse.<List<ChatMessageResponse>>builder()
+                .result(chatMessageService.getMessages(conversationId))
+                .build();
+    }
+}

--- a/chat-service/src/main/java/com/vti/chat/dto/request/ChatMessageRequest.java
+++ b/chat-service/src/main/java/com/vti/chat/dto/request/ChatMessageRequest.java
@@ -1,0 +1,18 @@
+package com.vti.chat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ChatMessageRequest {
+    @NotBlank
+    String conversationId;
+
+    @NotBlank
+    String message;
+}

--- a/chat-service/src/main/java/com/vti/chat/dto/response/ChatMessageResponse.java
+++ b/chat-service/src/main/java/com/vti/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,27 @@
+package com.vti.chat.dto.response;
+
+import com.vti.chat.entity.ParticipantInfo;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ChatMessageResponse {
+    // ID của tin nhắn
+    String id;
+    // ID của cuộc trò chuyện mà tin nhắn này thuộc về
+    String conversationId;
+    // Đánh dấu tin nhắn này có phải do người dùng hiện tại gửi hay không
+    boolean me;
+    // Nội dung tin nhắn
+    String message;
+    // Thông tin người gửi tin nhắn
+    ParticipantInfo sender;
+    // Thời điểm tin nhắn được tạo
+    Instant createdDate;
+}

--- a/chat-service/src/main/java/com/vti/chat/entity/ChatMessage.java
+++ b/chat-service/src/main/java/com/vti/chat/entity/ChatMessage.java
@@ -1,0 +1,40 @@
+package com.vti.chat.entity;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.MongoId;
+
+import java.time.Instant;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "chat_message")
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ChatMessage {
+    @MongoId
+    String id;
+
+    @Indexed
+    String conversationId;
+
+    String message;
+
+    // Thông tin của người gửi tin nhắn
+    ParticipantInfo sender;
+
+    @Indexed
+    Instant createdDate;
+}
+
+/*
+  @Indexed là annotation của Spring Data MongoDB dùng để tạo chỉ mục (index) cho một trường trong entity.
+ * Khi trường được đánh dấu @Indexed, MongoDB sẽ tự động tạo index cho trường đó trong collection tương ứng.
+ * Index giúp tăng tốc độ truy vấn (tìm kiếm, lọc, sắp xếp) trên trường này, đặc biệt khi dữ liệu lớn.
+ * Tuy nhiên, việc tạo quá nhiều index có thể làm chậm quá trình ghi (insert/update) và tốn thêm dung lượng lưu trữ.
+ */

--- a/chat-service/src/main/java/com/vti/chat/exception/ErrorCode.java
+++ b/chat-service/src/main/java/com/vti/chat/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     UNAUTHENTICATED(1006, "Unauthenticated", HttpStatus.UNAUTHORIZED),
     UNAUTHORIZED(1007, "You do not have permission", HttpStatus.FORBIDDEN),
     INVALID_DOB(1008, "Your age must be at least {min}", HttpStatus.BAD_REQUEST),
-    ;
+    CONVERSATION_NOT_FOUND(1009, "Chat Conversation not found" , HttpStatus.NOT_FOUND ),;
 
     ErrorCode(int code, String message, HttpStatusCode statusCode) {
         this.code = code;

--- a/chat-service/src/main/java/com/vti/chat/mapper/ChatMessageMapper.java
+++ b/chat-service/src/main/java/com/vti/chat/mapper/ChatMessageMapper.java
@@ -1,0 +1,17 @@
+package com.vti.chat.mapper;
+
+import com.vti.chat.dto.request.ChatMessageRequest;
+import com.vti.chat.dto.response.ChatMessageResponse;
+import com.vti.chat.entity.ChatMessage;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface ChatMessageMapper {
+    ChatMessageResponse toChatMessageResponse(ChatMessage chatMessage);
+
+    ChatMessage toChatMessage(ChatMessageRequest request);
+
+    List<ChatMessageResponse> toChatMessageResponses(List<ChatMessage> chatMessages);
+}

--- a/chat-service/src/main/java/com/vti/chat/repository/ChatMessageRepository.java
+++ b/chat-service/src/main/java/com/vti/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,12 @@
+package com.vti.chat.repository;
+
+import com.vti.chat.entity.ChatMessage;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+    List<ChatMessage> findAllByConversationIdOrderByCreatedDateDesc(String conversationId);
+}

--- a/chat-service/src/main/java/com/vti/chat/service/ChatMessageService.java
+++ b/chat-service/src/main/java/com/vti/chat/service/ChatMessageService.java
@@ -1,0 +1,98 @@
+package com.vti.chat.service;
+
+import com.vti.chat.dto.request.ChatMessageRequest;
+import com.vti.chat.dto.response.ChatMessageResponse;
+import com.vti.chat.entity.ChatMessage;
+import com.vti.chat.entity.ParticipantInfo;
+import com.vti.chat.exception.AppException;
+import com.vti.chat.exception.ErrorCode;
+import com.vti.chat.mapper.ChatMessageMapper;
+import com.vti.chat.repository.ChatMessageRepository;
+import com.vti.chat.repository.ConversationRepository;
+import com.vti.chat.repository.httpclient.ProfileClient;
+import jakarta.validation.Valid;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class ChatMessageService {
+    ChatMessageRepository chatMessageRepository;
+    ConversationRepository conversationRepository;
+    ProfileClient profileClient;
+    private final ChatMessageMapper chatMessageMapper;
+
+    public ChatMessageResponse create(@Valid ChatMessageRequest request) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        // Validate conversationId
+        var conversation = conversationRepository.findById(request.getConversationId())
+                .orElseThrow(
+                        () -> new AppException(ErrorCode.CONVERSATION_NOT_FOUND))
+                .getParticipants()
+                .stream()
+                .filter(
+                participantInfo -> userId.equals(participantInfo.getUserId()))
+                .findAny()
+                .orElseThrow(() -> new AppException(ErrorCode.CONVERSATION_NOT_FOUND));
+
+        // Get User Info from Profile Service
+        var userResponse = profileClient.getProfile(userId);
+        if (Objects.isNull(userResponse)) {
+            throw new AppException(ErrorCode.UNCATEGORIZED_EXCEPTION);
+        }
+
+        var userInfo = userResponse.getResult();
+
+        // Build Chat Message Info
+        ChatMessage chatMessage = chatMessageMapper.toChatMessage(request);
+        chatMessage.setSender(ParticipantInfo.builder()
+                        .userId(userInfo.getUserId())
+                        .username(userInfo.getUsername())
+                        .firstName(userInfo.getFirstName())
+                        .lastName(userInfo.getLastName())
+                        .avatar(userInfo.getAvatar())
+                .build());
+        chatMessage.setCreatedDate(Instant.now());
+
+        //Create Chat Message
+        chatMessage = chatMessageRepository.save(chatMessage);
+
+        // Convert to Response
+        return toChatMessageResponse(chatMessage);
+    }
+
+    public List<ChatMessageResponse> getMessages(String conversationId) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        // Validate conversationId
+        var conversation = conversationRepository.findById(conversationId)
+                .orElseThrow(
+                        () -> new AppException(ErrorCode.CONVERSATION_NOT_FOUND))
+                .getParticipants()
+                .stream()
+                .filter(
+                        participantInfo -> userId.equals(participantInfo.getUserId()))
+                .findAny()
+                .orElseThrow(() -> new AppException(ErrorCode.CONVERSATION_NOT_FOUND));
+
+        var messages = chatMessageRepository.findAllByConversationIdOrderByCreatedDateDesc(conversationId);
+
+        return messages.stream().map(this::toChatMessageResponse).toList();
+    }
+
+    private ChatMessageResponse toChatMessageResponse(ChatMessage chatMessage) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        var chatMessageResponse = chatMessageMapper.toChatMessageResponse(chatMessage);
+        chatMessageResponse.setMe(userId.equals(chatMessage.getSender().getUserId()));
+        return chatMessageResponse;
+    }
+}

--- a/chat-service/src/main/java/com/vti/chat/service/ConversationService.java
+++ b/chat-service/src/main/java/com/vti/chat/service/ConversationService.java
@@ -76,34 +76,37 @@ public class ConversationService {
         var sortedIds = userIds.stream().sorted().toList();
         String userIdsHash = generateParticipantHash(sortedIds);
 
-        // Tạo danh sách thông tin người tham gia
-        List<ParticipantInfo> participantInfos = List.of(
-                ParticipantInfo.builder()
-                        .userId(userInfo.getUserId())
-                        .username(userInfo.getUsername())
-                        .firstName(userInfo.getFirstName())
-                        .lastName(userInfo.getLastName())
-                        .avatar(userInfo.getAvatar())
-                        .build(),
-                ParticipantInfo.builder()
-                        .userId(participantInfo.getUserId())
-                        .username(participantInfo.getUsername())
-                        .firstName(participantInfo.getFirstName())
-                        .lastName(participantInfo.getLastName())
-                        .avatar(participantInfo.getAvatar())
-                        .build()
-        );
+        var conversation = conversationRepository.findByParticipantsHash(userIdsHash)
+                .orElseGet(() ->{
+                    // Tạo danh sách thông tin người tham gia
+                    List<ParticipantInfo> participantInfos = List.of(
+                            ParticipantInfo.builder()
+                                    .userId(userInfo.getUserId())
+                                    .username(userInfo.getUsername())
+                                    .firstName(userInfo.getFirstName())
+                                    .lastName(userInfo.getLastName())
+                                    .avatar(userInfo.getAvatar())
+                                    .build(),
+                            ParticipantInfo.builder()
+                                    .userId(participantInfo.getUserId())
+                                    .username(participantInfo.getUsername())
+                                    .firstName(participantInfo.getFirstName())
+                                    .lastName(participantInfo.getLastName())
+                                    .avatar(participantInfo.getAvatar())
+                                    .build()
+                    );
 
-        // Khởi tạo đối tượng Conversation và lưu vào database
-        Conversation conversation = Conversation.builder()
-                .type(request.getType())
-                .participantsHash(userIdsHash)
-                .createdDate(Instant.now())
-                .modifiedDate(Instant.now())
-                .participants(participantInfos)
-                .build();
+                    // Khởi tạo đối tượng Conversation và lưu vào database
+                    Conversation newConversation = Conversation.builder()
+                            .type(request.getType())
+                            .participantsHash(userIdsHash)
+                            .createdDate(Instant.now())
+                            .modifiedDate(Instant.now())
+                            .participants(participantInfos)
+                            .build();
+                    return conversationRepository.save(newConversation);
+                });
 
-        conversation = conversationRepository.save(conversation);
         return toConversationResponse(conversation);
     }
 

--- a/chat-service/src/main/resources/application.yaml
+++ b/chat-service/src/main/resources/application.yaml
@@ -8,6 +8,7 @@ spring:
   data:
     mongodb:
       uri: mongodb://root:251101@localhost:27017/chat-service?authSource=admin
+      auto-index-creation: true
 
 app:
   services:

--- a/web-app/src/configurations/configuration.js
+++ b/web-app/src/configurations/configuration.js
@@ -12,4 +12,6 @@ export const API = {
   SEARCH_USER: "/profile/users/search",
   MY_CONVERSATIONS: "/chat/conversations/my-conversations",
   CREATE_CONVERSATION: "/chat/conversations/create",
+  CREATE_MESSAGE: "/chat/messages/create",
+  GET_CONVERSATION_MESSAGES: "/chat/messages",
 };


### PR DESCRIPTION
This pull request introduces the chat message feature to the chat service, enabling users to send and retrieve messages within conversations. The changes include new endpoints, data models, validation, and integration with MongoDB for message persistence. Additionally, related configuration and error handling are updated to support this functionality.

**Chat Message Feature Implementation:**

* Added `ChatMessageController` with endpoints to create a message and retrieve messages for a conversation (`/messages/create` and `/messages`).
* Introduced `ChatMessageService` to handle business logic for message creation and retrieval, including validation of conversation participation and integration with the profile service.
* Created `ChatMessageRequest` and `ChatMessageResponse` DTOs for request validation and API responses. [[1]](diffhunk://#diff-80ef584fe38d778006f7e66ba9afe77564f0265b28ccd0ac53b39ff91fb16f2cR1-R18) [[2]](diffhunk://#diff-4cbc3275649fbe6d654198e0c34b75610b764d7b52140234d351eb9e2591edbeR1-R27)
* Added `ChatMessage` entity with indexed fields for efficient MongoDB queries, and explained indexing in comments.
* Implemented `ChatMessageMapper` using MapStruct for mapping between DTOs and entity.
* Added `ChatMessageRepository` with a method to find messages by conversation, ordered by creation date.

**Configuration and Error Handling:**

* Enabled automatic MongoDB index creation in `application.yaml` to support efficient querying on indexed fields.
* Added `CONVERSATION_NOT_FOUND` error code for better error reporting when a conversation does not exist.

**Frontend API Integration:**

* Updated frontend API configuration to include endpoints for creating and retrieving chat messages.

**Other Minor Changes:**

* Cleaned up `.idea/compiler.xml` to remove duplicate or unnecessary Maven dependencies.
* Improved conversation creation logic to prevent duplicate conversations by checking participant hashes. [[1]](diffhunk://#diff-3c4dc9376d4471a97077258bb2bcb63a0568782a9b2589e88dabef9f18c53100R79-R80) [[2]](diffhunk://#diff-3c4dc9376d4471a97077258bb2bcb63a0568782a9b2589e88dabef9f18c53100L98-L106)