### PR TITLE
add identity service integration for token introspection in WebSocket connections v1

### DIFF
--- a/chat-service/src/main/java/com/vti/chat/controller/SocketHandler.java
+++ b/chat-service/src/main/java/com/vti/chat/controller/SocketHandler.java
@@ -5,6 +5,8 @@ import com.corundumstudio.socketio.SocketIOServer;
 import com.corundumstudio.socketio.annotation.OnConnect;
 import com.corundumstudio.socketio.annotation.OnDisconnect;
 import com.corundumstudio.socketio.annotation.OnEvent;
+import com.vti.chat.dto.request.IntrospectRequest;
+import com.vti.chat.service.IdentityService;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.AccessLevel;
@@ -20,10 +22,26 @@ import org.springframework.stereotype.Component;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class SocketHandler {
     SocketIOServer server;
+    IdentityService identityService;
 
     @OnConnect
     public void clientConnected(SocketIOClient client) {
-        log.info("Client connected: {}", client.getSessionId());
+        // Get Token from request parameter
+        String token = client.getHandshakeData().getSingleUrlParam("token");
+
+        // Verify token
+        var introspectResponse = identityService.introspect(
+                IntrospectRequest.builder()
+                        .token(token)
+                        .build());
+
+        // If the token is invalid, disconnect the client,
+        if (introspectResponse.isValid()) {
+            log.info("Client connected: {}, {}", client.getSessionId(), token);
+        } else {
+            log.error("Authentication fail: {}", client.getSessionId());
+            client.disconnect();
+        }
     }
 
     @OnDisconnect

--- a/chat-service/src/main/java/com/vti/chat/dto/request/IntrospectRequest.java
+++ b/chat-service/src/main/java/com/vti/chat/dto/request/IntrospectRequest.java
@@ -1,0 +1,13 @@
+package com.vti.chat.dto.request;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class IntrospectRequest {
+    String token;
+}

--- a/chat-service/src/main/java/com/vti/chat/dto/response/IntrospectResponse.java
+++ b/chat-service/src/main/java/com/vti/chat/dto/response/IntrospectResponse.java
@@ -1,0 +1,13 @@
+package com.vti.chat.dto.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class IntrospectResponse {
+    boolean valid;
+}

--- a/chat-service/src/main/java/com/vti/chat/repository/httpclient/IdentityClient.java
+++ b/chat-service/src/main/java/com/vti/chat/repository/httpclient/IdentityClient.java
@@ -1,0 +1,14 @@
+package com.vti.chat.repository.httpclient;
+
+import com.vti.chat.dto.ApiResponse;
+import com.vti.chat.dto.request.IntrospectRequest;
+import com.vti.chat.dto.response.IntrospectResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "identity-service", url = "${app.services.identity.url}")
+public interface IdentityClient {
+    @PostMapping("/auth/introspect")
+    ApiResponse<IntrospectResponse> introspect(@RequestBody IntrospectRequest request);
+}

--- a/chat-service/src/main/java/com/vti/chat/service/IdentityService.java
+++ b/chat-service/src/main/java/com/vti/chat/service/IdentityService.java
@@ -1,0 +1,38 @@
+package com.vti.chat.service;
+
+import com.vti.chat.dto.request.IntrospectRequest;
+import com.vti.chat.dto.response.IntrospectResponse;
+import com.vti.chat.repository.httpclient.IdentityClient;
+import feign.FeignException;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class IdentityService {
+    IdentityClient identityClient;
+
+    public IntrospectResponse introspect(IntrospectRequest request) {
+        try {
+            var result =  identityClient.introspect(request).getResult();
+            if (Objects.isNull(result)) {
+                return IntrospectResponse.builder()
+                        .valid(false)
+                        .build();
+            }
+            return result;
+        } catch (FeignException e) {
+            log.error("Introspect failed: {}", e.getMessage(), e);
+            return IntrospectResponse.builder()
+                    .valid(false)
+                    .build();
+        }
+    }
+}

--- a/chat-service/src/main/resources/application.yaml
+++ b/chat-service/src/main/resources/application.yaml
@@ -14,3 +14,5 @@ app:
   services:
     profile:
       url: http://localhost:8081/profile
+    identity:
+      url: http://localhost:8080/identity

--- a/web-app/src/pages/Chat.jsx
+++ b/web-app/src/pages/Chat.jsx
@@ -29,6 +29,7 @@ import {
   createMessage,
 } from "../services/chatService";
 import { io } from "socket.io-client";
+import { getToken } from "../services/localStorageService";
 
 export default function Chat() {
   const [message, setMessage] = useState("");
@@ -178,7 +179,10 @@ export default function Chat() {
   useEffect(() => {
     // Initialize socket connection
     console.log("Initializing socket connection...");
-    const socket = new io("http://localhost:8099");
+
+    const connectionUrl = "http://localhost:8099?token=" + getToken();
+
+    const socket = new io(connectionUrl);
     
     socket.on("connect", () => {
       console.log("Socket connected");


### PR DESCRIPTION
This pull request introduces authentication for socket connections in the chat service by integrating token-based validation with an external identity service. The main changes include backend support for token introspection, a new HTTP client for identity verification, and frontend updates to send tokens during socket connection.

**Backend authentication integration:**

* Added `IdentityService` to handle token introspection by calling the new `IdentityClient` Feign client, which communicates with the identity service to validate tokens. (`chat-service/src/main/java/com/vti/chat/service/IdentityService.java`, `chat-service/src/main/java/com/vti/chat/repository/httpclient/IdentityClient.java`) [[1]](diffhunk://#diff-189ac76fbc2746a8edeba4fed4412112725b244842449f83bf773808e45b6781R1-R38) [[2]](diffhunk://#diff-0512b30db892c131b0208a0a6b3c8496b28d84085a7788b6a9278bed29576fb1R1-R14)
* Introduced DTOs for introspection requests and responses: `IntrospectRequest` and `IntrospectResponse`. (`chat-service/src/main/java/com/vti/chat/dto/request/IntrospectRequest.java`, `chat-service/src/main/java/com/vti/chat/dto/response/IntrospectResponse.java`) [[1]](diffhunk://#diff-c80e75749736982ff41df47c4ed953fd8aac10b9924f6f52633779f0dd6deaeeR1-R13) [[2]](diffhunk://#diff-93699f4cf58c8f43f13331d1952434bc03b23f211b77c5ddfcfc5df4c21311acR1-R13)
* Updated `SocketHandler` so that on client connection, it extracts the token from the connection URL, validates it using `IdentityService`, and disconnects clients with invalid tokens. (`chat-service/src/main/java/com/vti/chat/controller/SocketHandler.java`) [[1]](diffhunk://#diff-40039ed25304e49af4fa3946f4ee805d9f93b0bfdd78cc0d288e00019a050300R8-R9) [[2]](diffhunk://#diff-40039ed25304e49af4fa3946f4ee805d9f93b0bfdd78cc0d288e00019a050300R25-R44)
* Configured the identity service URL in `application.yaml` under `app.services.identity.url`. (`chat-service/src/main/resources/application.yaml`)

**Frontend token transmission:**

* Modified the chat page to append the user's token as a query parameter when establishing a socket connection, using the `getToken` utility. (`web-app/src/pages/Chat.jsx`) [[1]](diffhunk://#diff-70f2473b623bb57b6871a6a2a3e0bdb2d47207474c8ac63ca1683fad3e858b16R32) [[2]](diffhunk://#diff-70f2473b623bb57b6871a6a2a3e0bdb2d47207474c8ac63ca1683fad3e858b16L181-R185)